### PR TITLE
fixes misleading documentation

### DIFF
--- a/pdns/arguments.hh
+++ b/pdns/arguments.hh
@@ -104,7 +104,7 @@ public:
   string &set(const string &); //!< Gives a writable reference and allocates space for it
   string &set(const string &, const string &); //!< Does the same but also allows one to specify a help message
   void setCmd(const string &, const string &); //!< Add a command flag
-  string &setSwitch(const string &, const string &); //!< Add a command flag
+  string &setSwitch(const string &, const string &); //!< Add a switch flag
   string helpstring(string prefix=""); //!< generates the --help
   string configstring(bool current=false); //!< generates the --mkconfig
   bool contains(const string &var, const string &val);


### PR DESCRIPTION
Fixes misleading documentation for the `setSwitch` function.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
